### PR TITLE
Depend on noddity-retrieval 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "extend": "^2.0.0",
     "levelup-cache": "^2.0.0",
-    "noddity-retrieval": "~1.3.0",
+    "noddity-retrieval": "^1.3.0",
     "run-parallel": "^1.1.2",
     "subleveldown": "^2.0.0",
     "weak-type-wizard": "^1.2.4"


### PR DESCRIPTION
Allows noddity-retrieval 1.4.0 to be loaded.